### PR TITLE
add support for BlobURL subworkers in Chrome + Safari

### DIFF
--- a/subworkers.js
+++ b/subworkers.js
@@ -110,10 +110,10 @@
       throw new TypeError("Failed to construct 'Worker': Please use the 'new' operator, this DOM object constructor cannot be called as a function.");
     }
 
-    if (path.indexOf('blob:') !== -1) {
-      if (path.indexOf('blob:') !== 0 ) {
-        path = 'blob:' + path.split('blob:')[1];
-      }
+    var blobIndex = path.indexOf('blob:');
+    
+    if (blobIndex !== -1 && blobIndex !== 0 ) {
+      path = path.substring(blobIndex);
     }
 
     var newWorker = new oldWorker(path);

--- a/subworkers.js
+++ b/subworkers.js
@@ -109,6 +109,13 @@
     if (this.constructor !== Worker){
       throw new TypeError("Failed to construct 'Worker': Please use the 'new' operator, this DOM object constructor cannot be called as a function.");
     }
+
+    if (path.indexOf('blob:') !== -1) {
+      if (path.indexOf('blob:') !== 0 ) {
+        path = 'blob:' + path.split('blob:')[1];
+      }
+    }
+
     var newWorker = new oldWorker(path);
     newWorker.addEventListener("message", messageRecieved);
 

--- a/test/blob-browser.js
+++ b/test/blob-browser.js
@@ -1,0 +1,7 @@
+var mainWorker = new Worker("main-worker-blob.js");
+mainWorker.postMessage("start");
+mainWorker.addEventListener("message",function (e) {
+  if (e.data === "success"){
+    document.getElementById("blob-url-output").textContent = "Success!";
+  }
+})

--- a/test/browser.js
+++ b/test/browser.js
@@ -2,6 +2,6 @@ var mainWorker = new Worker("main-worker.js");
 mainWorker.postMessage("start");
 mainWorker.addEventListener("message",function (e) {
   if (e.data === "success"){
-    document.getElementById("output").innerText += "Success!";
+    document.getElementById("url-output").textContent = "Success!";
   }
 })

--- a/test/main-worker-blob.js
+++ b/test/main-worker-blob.js
@@ -1,0 +1,25 @@
+importScripts("../subworkers.js");
+
+var childWorkerStr = '';
+childWorkerStr += "self.addEventListener('message',function(e){";
+childWorkerStr += "  if (e.data === 'ping'){";
+childWorkerStr += "    self.postMessage('pong');";
+childWorkerStr += "  }";
+childWorkerStr += "});";
+
+var childfWorkerURL = URL.createObjectURL(
+  new Blob([ childWorkerStr ], {type: 'text/javascript'})
+);
+
+var subWorker = new Worker(childfWorkerURL);
+subWorker.addEventListener('message',function(e){
+  if (e.data === "pong"){
+    self.postMessage("success");
+  }
+});
+
+self.addEventListener('message',function(e){
+  if (e.data === "start"){
+    subWorker.postMessage("ping");
+  }
+});

--- a/test/main-worker.js
+++ b/test/main-worker.js
@@ -1,5 +1,4 @@
 importScripts("../subworkers.js");
-
 var subWorker = new Worker("child-worker.js");
 subWorker.addEventListener('message',function(e){
   if (e.data === "pong"){

--- a/test/test.html
+++ b/test/test.html
@@ -3,10 +3,15 @@
   <head>
     <script src="../subworkers.js"></script>
     <script src="browser.js"></script>
+    <script src="blob-browser.js"></script>
   </head>
   <body>
     <h1>Subworker Test</h1>
-    <pre id="output">
+    <h2>Subworker</h2>
+    <pre id="url-output">
+    </pre>
+    <h2>Subworker with Blob URL</h2>
+    <pre id="blob-url-output">
     </pre>
   </body>
 </html>


### PR DESCRIPTION
Hey @dmihal,

Thank you for creating this polyfill. It's working really well and I'm using it in one of my projects.

I noticed a little issue in Chrome and Safari: The subworker wouldn't load if it was instantiated with a ``BlobURL``.

This pull request fixes the issue. The code I added does the following:
* it checks if the the worker URL contains `blob:`
* if it does contain `blob:` but doesn't start with `blob:`, everything before `blob:` is removed.

I also added a test for this issue. Please let me know if you have any questions.

Thanks again for creating this polyfill!