### PR TITLE
Fixed ReferenceError crash

### DIFF
--- a/subworkers.js
+++ b/subworkers.js
@@ -61,6 +61,7 @@
           }
         },
         removeEventListener: function(type, listener, useCapture){
+          if(!(type in this.eventListeners)) return;
           var index = this.eventListeners[type].indexOf(listener);
           if (index !== -1){
             this.eventListeners[type].splice(index, 1);

--- a/subworkers.js
+++ b/subworkers.js
@@ -63,7 +63,7 @@
         removeEventListener: function(type, listener, useCapture){
           var index = this.eventListeners[type].indexOf(listener);
           if (index !== -1){
-            this.eventListeners[type].splice(idx, 1);
+            this.eventListeners[type].splice(index, 1);
           }
         },
         dispatchEvent: function(event){


### PR DESCRIPTION
Fixed fatal subworker error resulting in a ReferenceError for “idx”
(likely a typo, should have been “index”) along a lesser-used code path.