### PR TITLE
Don't double-slash the worker's path

### DIFF
--- a/subworkers.js
+++ b/subworkers.js
@@ -29,7 +29,8 @@
         });
 
         var location = self.location.pathname;
-        var absPath = location.substring(0, location.lastIndexOf('/')) + '/' + path;
+        var slashedPath = path.charAt(0) == '/' ? path : '/' + path;
+        var absPath = location.substring(0, location.lastIndexOf('/')) + slashedPath;
         self.postMessage({
           _subworker: true,
           cmd: 'newWorker',


### PR DESCRIPTION
This minor change prevents the following unwanted behavior: 
Providing `/a.js` as the worker's path transforms it loads `//a.js`, which means it treats the path as a different domain.
If somebody desires to load the worker from a different URL(very unlikely) can still use `//` as in the normal Worker constructor.